### PR TITLE
changed the name of the project to the new name of the github repo

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>SLSystemSuit</name>
+	<name>Spikes-Lib</name>
 	<comment></comment>
 	<projects>
 	</projects>


### PR DESCRIPTION
changed the name of the project in the .project file from SLSystemSuit to Spikes-Lib. thus making the name up to date with the name of the github repo and avoiding confusion while importion and building jars from that project